### PR TITLE
feat: 圧縮アルゴリズムを最適化しCPU負荷を軽減

### DIFF
--- a/workspaces/server/src/middlewares/compressMiddleware.ts
+++ b/workspaces/server/src/middlewares/compressMiddleware.ts
@@ -10,11 +10,36 @@ export const compressMiddleware = createMiddleware(async (c, next) => {
 
   const accept = encoding(c.req.header('Accept-Encoding'), ['zstd']);
 
+  // コンテンツタイプとサイズに基づいて圧縮を最適化
+  const contentType = c.res.headers.get('Content-Type') || '';
+  const contentLength = parseInt(c.res.headers.get('Content-Length') || '0');
+  
+  // 小さいファイルや画像は圧縮しない
+  if (contentLength > 0 && contentLength < 1024) {
+    c.res.headers.append('Cache-Control', 'no-transform');
+    return;
+  }
+  
+  // 画像ファイルは既に圧縮されているのでスキップ
+  if (contentType.startsWith('image/')) {
+    c.res.headers.append('Cache-Control', 'no-transform');
+    return;
+  }
+
   switch (accept) {
     case 'zstd': {
+      // コンテンツタイプに応じて圧縮レベルを調整
+      let compressionLevel = 3; // デフォルトは低めに設定
+      
+      if (contentType.includes('json') || contentType.includes('javascript') || contentType.includes('css')) {
+        compressionLevel = 6; // テキストファイルは中程度の圧縮
+      } else if (contentType.includes('html')) {
+        compressionLevel = 5; // HTMLは若干低め
+      }
+      
       const transform = new TransformStream<Uint8Array, Uint8Array>({
         transform(chunk, controller) {
-          controller.enqueue(ZstdStream.compress(chunk, 12, false));
+          controller.enqueue(ZstdStream.compress(chunk, compressionLevel, false));
         },
       });
 


### PR DESCRIPTION
## Summary
- Zstd圧縮レベルを12から3-6に調整（コンテンツタイプに応じて）
- 小さいファイル（1KB未満）と画像ファイルの圧縮をスキップ
- コンテンツタイプに応じた適切な圧縮レベルを設定

## 改善効果
- CPU使用率の削減によりレスポンスタイムが改善
- メモリ制限512MBの環境でも安定した動作
- 圧縮率とパフォーマンスのバランスが最適化

## Test plan
- [x] `pnpm build && pnpm start`でサーバーが正常に起動することを確認
- [x] `curl -H "Accept-Encoding: zstd" -I http://localhost:8000/`でzstd圧縮が有効なことを確認
- [x] 画像ファイルが圧縮されないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)