### PR TITLE
feat: Service Workerによるキャッシュ戦略を実装

### DIFF
--- a/workspaces/client/src/serviceworker/index.ts
+++ b/workspaces/client/src/serviceworker/index.ts
@@ -2,12 +2,32 @@
 
 import { transformJpegXLToBmp } from './transformJpegXLToBmp';
 
+const CACHE_NAME = 'wsh-2024-v1';
+const CACHE_DURATION = 24 * 60 * 60 * 1000; // 24時間
+
+// キャッシュするリソースのパターン
+const CACHE_PATTERNS = [
+  /\/assets\//,  // 静的アセット
+  /\/images\//,  // 画像API
+  /\.js$/,       // JavaScriptファイル
+  /\.css$/,      // CSSファイル
+  /\.woff$/,     // フォントファイル
+];
+
 self.addEventListener('install', (ev: ExtendableEvent) => {
   ev.waitUntil(self.skipWaiting());
 });
 
 self.addEventListener('activate', (ev: ExtendableEvent) => {
-  ev.waitUntil(self.clients.claim());
+  ev.waitUntil(
+    caches.keys().then(cacheNames => {
+      return Promise.all(
+        cacheNames
+          .filter(cacheName => cacheName !== CACHE_NAME)
+          .map(cacheName => caches.delete(cacheName))
+      );
+    }).then(() => self.clients.claim())
+  );
 });
 
 self.addEventListener('fetch', (ev: FetchEvent) => {
@@ -15,14 +35,70 @@ self.addEventListener('fetch', (ev: FetchEvent) => {
 });
 
 async function onFetch(request: Request): Promise<Response> {
-  const res = await fetch(request);
+  // キャッシュ可能なリソースかチェック
+  const shouldCache = CACHE_PATTERNS.some(pattern => pattern.test(request.url));
+  
+  if (shouldCache && request.method === 'GET') {
+    // キャッシュファーストストラテジー
+    const cached = await caches.match(request);
+    if (cached) {
+      // キャッシュの有効期限をチェック
+      const cacheDate = cached.headers.get('sw-cache-date');
+      if (cacheDate) {
+        const age = Date.now() - parseInt(cacheDate);
+        if (age < CACHE_DURATION) {
+          return cached;
+        }
+      }
+    }
+  }
 
-  if (res.headers.get('Content-Type') === 'image/jxl') {
-    // If the response is a JPEG XL image, transform it to BMP format.
-    // JPEG XL は Chrome ではサポートされていないため、BMP に変換して返す。
-    // wasm が使われているため、Viteに移行しようとするとこの処理がネックになる
-    return transformJpegXLToBmp(res);
-  } else {
+  // ネットワークリクエスト
+  try {
+    const res = await fetch(request);
+    
+    // JPEG XLの変換処理
+    if (res.headers.get('Content-Type') === 'image/jxl') {
+      const transformedRes = await transformJpegXLToBmp(res);
+      
+      // 変換済み画像もキャッシュする
+      if (shouldCache && res.ok) {
+        const cache = await caches.open(CACHE_NAME);
+        const responseToCache = transformedRes.clone();
+        const headers = new Headers(responseToCache.headers);
+        headers.set('sw-cache-date', Date.now().toString());
+        const cachedResponse = new Response(responseToCache.body, {
+          status: responseToCache.status,
+          statusText: responseToCache.statusText,
+          headers: headers
+        });
+        cache.put(request, cachedResponse);
+      }
+      
+      return transformedRes;
+    }
+    
+    // 通常のレスポンスもキャッシュ
+    if (shouldCache && res.ok) {
+      const cache = await caches.open(CACHE_NAME);
+      const responseToCache = res.clone();
+      const headers = new Headers(responseToCache.headers);
+      headers.set('sw-cache-date', Date.now().toString());
+      const cachedResponse = new Response(responseToCache.body, {
+        status: responseToCache.status,
+        statusText: responseToCache.statusText,
+        headers: headers
+      });
+      cache.put(request, cachedResponse);
+    }
+    
     return res;
+  } catch (error) {
+    // ネットワークエラー時はキャッシュから返す
+    const cached = await caches.match(request);
+    if (cached) {
+      return cached;
+    }
+    throw error;
   }
 }


### PR DESCRIPTION
## Summary
- 静的リソース（画像、JS、CSS、フォント）のキャッシュ実装
- キャッシュファーストストラテジーで高速化
- 24時間のキャッシュ有効期限を設定
- ネットワークエラー時はキャッシュから配信

## 改善効果
- 2回目以降のアクセスで静的リソースが即座に配信
- ネットワーク遅延の影響を受けない
- オフラインでもキャッシュ済みリソースは表示可能
- 特に画像の再読み込みが高速化

## Test plan
- [x] `pnpm build && pnpm start`でサーバーが正常に起動することを確認
- [x] DevToolsでService Workerが登録されることを確認
- [x] Application > Cacheに静的リソースがキャッシュされることを確認
- [x] 2回目のアクセスでキャッシュから配信されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)